### PR TITLE
Update EntityViewInspector

### DIFF
--- a/src/Assets/EcsRx/UnityEditor/Editor/EntityViewInspector.cs
+++ b/src/Assets/EcsRx/UnityEditor/Editor/EntityViewInspector.cs
@@ -19,9 +19,9 @@ namespace EcsRx.UnityEditor.Editor
         public bool showComponents;
 
         private readonly IEnumerable<Type> allComponentTypes = AppDomain.CurrentDomain.GetAssemblies()
-                                .SelectMany(s => s.GetTypes())
-                                .Where(p => typeof(IComponent).IsAssignableFrom(p) && p.IsClass);
-
+            .SelectMany(s => s.GetTypes())
+            .Where(p => typeof(IComponent).IsAssignableFrom(p) && p.IsClass)
+            .ToArray();
 
         private void PoolSection()
         {


### PR DESCRIPTION
Hello! I noticed that when opening a custom inspector for the "EntityView" type in runtime, Unity is lagging. This happens due to access to the allComponentTypes field inside the EntityViewInspector script. The ".SelectMany()" and ".Where()" methods are deferred methods. This means that they will not be executed until the method with immediate execution is called. 
Because of this, a resource-intensive operation of iterating over all classes in all assemblies is performed every time ".OnInspectorGUI()" is called. 
To fix this you just need to add a linq method with immediate execution when initializing the "allComponentTypes" field. For example ".ToArray()".